### PR TITLE
Add explicit checking for correct version of Apple WWDR certificate.

### DIFF
--- a/PassValidator.Web/Validation/ValidationResult.cs
+++ b/PassValidator.Web/Validation/ValidationResult.cs
@@ -45,6 +45,8 @@
 
         public bool WWDRCertificateSubjectMatches { get; set; }
 
+        public bool WWDRCertificateIsCorrectVersion { get; set; }
+
         public bool HasAuthenticationToken { get; set; }
 
         public bool HasWebServiceUrl { get; set; }

--- a/PassValidator.Web/Views/Home/Index.cshtml
+++ b/PassValidator.Web/Views/Home/Index.cshtml
@@ -164,6 +164,7 @@
             </ul>
             <h3>WWDR Certificate</h3>
             <ul>
+                <li><i data-bind="css: getStyle(wwdrCertificateIsCorrectVersion())"></i>WWDR Certificate is <a href="#wwdc-certificate-versions">correct version (G1)</a></li>
                 <li><i data-bind="css: getStyle(wwdrCertificateSubjectMatches())"></i>WWDR Certificate Subject</li>
                 <li><i data-bind="css: getStyle(!wwdrCertificateExpired())"></i>WWDR Certificate in date</li>
             </ul>
@@ -177,6 +178,10 @@
             Failed to process the pkpass file.
         </div>
     </div>
+    <h3 id="wwdc-certificate-versions">WWDC Certificate Versions</h3>
+    <p>As of November 2021, the Apple PKI page at <a href="https://www.apple.com/certificateauthority/">https://www.apple.com/certificateauthority/</a>
+    lists five "Worldwide Developer Relations" certificates.</p>
+    <p><strong>Only the G1 certificate (expiring 02/07/2023 21:48:47 UTC) is valid for signing passes.</strong></p>
     <hr />
     <h2>Supporting this project</h2>
     <p>
@@ -277,6 +282,7 @@
 
                             self.wwdrCertificateExpired(jsonResponse.wwdrCertificateExpired);
                             self.wwdrCertificateSubjectMatches(jsonResponse.wwdrCertificateSubjectMatches);
+                            self.wwdrCertificateIsCorrectVersion(jsonResponse.wwdrCertificateIsCorrectVersion);
 
                             self.passKitCertificateNameCorrect(jsonResponse.passKitCertificateNameCorrect);
                             self.passKitCertificateExpired(jsonResponse.passKitCertificateExpired);
@@ -334,6 +340,7 @@
 
             self.wwdrCertificateExpired = ko.observable(false);
             self.wwdrCertificateSubjectMatches = ko.observable(false);
+            self.wwdrCertificateIsCorrectVersion = ko.observable(false);
 
             self.hasAuthenticationToken = ko.observable(false);
             self.authenticationTokenCorrectLength = ko.observable(false);


### PR DESCRIPTION
Instead of trusting any certificate with the correct common name, this checks for any valid WWDR certificate, but SEPARATELY validates whether the WWDR certificate is the correct/supported version.

Fixes https://github.com/tomasmcguinness/pkpassvalidator/issues/12
![image](https://user-images.githubusercontent.com/106178/145410378-62f3cbd0-546e-4390-a5d8-5805ded0684b.png)
