### PR TITLE
fix: actually note whether the pkcs7 signature is valid for the data

### DIFF
--- a/PassValidator.Console/ConsoleValidator.cs
+++ b/PassValidator.Console/ConsoleValidator.cs
@@ -53,6 +53,7 @@ public static class ConsoleValidator
     {
         return !validationResult.HasSignatureExpired &&
                 validationResult.HasSignature &&
+                validationResult.SignatureValid &&
                 validationResult.SignedByApple;
     }
 

--- a/PassValidator.Console/VerbosePrinter.cs
+++ b/PassValidator.Console/VerbosePrinter.cs
@@ -24,6 +24,7 @@ public static class VerbosePrinter
         System.Console.WriteLine($"\tPass Type Identifier Matches: {validationResult.PassTypeIdentifierMatches}");
         System.Console.WriteLine($"\tSigned By Apple: {validationResult.SignedByApple}");
         System.Console.WriteLine($"\tSignature Expiration Date: {validationResult.SignatureExpirationDate}");
+        System.Console.WriteLine($"\tSignature Valid: {validationResult.SignatureValid}");
         System.Console.WriteLine($"\tHas Icon 3x: {validationResult.HasIcon3x}");
         System.Console.WriteLine($"\tHas Icon 2x: {validationResult.HasIcon2x}");
         System.Console.WriteLine($"\tHas Icon 1x: {validationResult.HasIcon1x}");

--- a/PassValidator.Validator/ValidationResult.cs
+++ b/PassValidator.Validator/ValidationResult.cs
@@ -18,6 +18,8 @@ public class ValidationResult
 
     public string SignatureExpirationDate { get; set; }
 
+    public bool SignatureValid { get; set; }
+
     public bool HasIcon3x { get; set; }
 
     public bool HasIcon2x { get; set; }

--- a/PassValidator.Validator/Validator.cs
+++ b/PassValidator.Validator/Validator.cs
@@ -145,10 +145,11 @@ public class Validator
         try
         {
             signedCms.CheckSignature(true);
+            result.SignatureValid = true;
         }
         catch
         {
-            // ignored
+            result.SignatureValid = false;
         }
 
         var signer = signedCms.SignerInfos[0];


### PR DESCRIPTION
Turns out some pkpass files we were generating had an invalid signature for the manifest file due to a footgun in the Python cryptography package where it could silently convert the manifest.json text to S/MIME format before signing, which apparently is not what Apple is expecting either.

It still passed verification with this tool, but I just realized it was silently ignoring invalid signatures for some reason :)